### PR TITLE
Remove prototype function usage, fixes #8.

### DIFF
--- a/addon/mixins/graph-has-graph-parent.js
+++ b/addon/mixins/graph-has-graph-parent.js
@@ -23,9 +23,9 @@ export default Ember.Mixin.create({
     
     @method _getGraph
     */
-  _getGraph: function(){
+  _getGraph: Ember.on('init', function(){
     var graph = this.nearestWithProperty('isGraph');
     this.set('graph', graph);
     this.trigger('hasGraph', graph);
-  }.on('init'),
+  }),
 });

--- a/addon/mixins/graph-registered-graphic.js
+++ b/addon/mixins/graph-registered-graphic.js
@@ -13,12 +13,12 @@ export default Ember.Mixin.create({
     @method _registerGraphic
     @private
   */
-  _registerGraphic: function() {
+  _registerGraphic: Ember.on('didInsertElement', function() {
     var graph = this.get('graph');
     if(graph) {
       graph.registerGraphic(this);
     }
-  }.on('didInsertElement'),
+  }),
 
   /**
     calls {{#crossLink "components.nf-graph/unregisterGraphic"}}{{/crossLink}} on
@@ -26,10 +26,10 @@ export default Ember.Mixin.create({
     @method _unregisterGraphic
     @private
   */
-  _unregisterGraphic: function(){
+  _unregisterGraphic: Ember.on('willDestroyElement', function(){
     var graph = this.get('graph');
     if(graph) {
       graph.unregisterGraphic(this);
     }
-  }.on('willDestroyElement')
+  })
 });

--- a/addon/mixins/graph-requires-scale-source.js
+++ b/addon/mixins/graph-requires-scale-source.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 var scaleProperty = function(scaleKey, zoomKey, offsetKey){
-  return function() {
+  return Ember.computed(scaleKey, zoomKey, offsetKey, function() {
     var scale = this.get(scaleKey);
     var zoom = this.get(zoomKey);
     var offset = this.get(offsetKey);
@@ -17,7 +17,7 @@ var scaleProperty = function(scaleKey, zoomKey, offsetKey){
     copy.range([range[0] - offset, range[1] - offset]);
 
     return copy;
-  }.property(scaleKey, zoomKey, offsetKey);
+  });
 };
 
 /**
@@ -57,12 +57,12 @@ export default Ember.Mixin.create({
     @type Number
     @default 1
   */
-  scaleZoomX: function(key, value) {
+  scaleZoomX: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._scaleZoomX = +value;
     }
     return this._scaleZoomX || 1;
-  }.property(),
+  }),
 
   /**
     The zoom multiplier for the y scale
@@ -70,12 +70,12 @@ export default Ember.Mixin.create({
     @type Number
     @default 1
   */
-  scaleZoomY: function(key, value) {
+  scaleZoomY: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._scaleZoomY = +value;
     }
     return this._scaleZoomY || 1;
-  }.property(),
+  }),
 
   /**
     The offset, in pixels, for the x scale
@@ -83,12 +83,12 @@ export default Ember.Mixin.create({
     @type Number
     @default 0
   */
-  scaleOffsetX: function(key, value) {
+  scaleOffsetX: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._scaleOffsetX = +value;
     }
     return this._scaleOffsetX || 0;
-  }.property(),
+  }),
 
   /**
     The offset, in pixels, for the y scale
@@ -96,15 +96,15 @@ export default Ember.Mixin.create({
     @type Number
     @default 0
   */
-  scaleOffsetY: function(key, value) {
+  scaleOffsetY: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._scaleOffsetY = +value;
     }
     return this._scaleOffsetY || 0;
-  }.property(),
+  }),
 
-  _getScaleSource: function(){
+  _getScaleSource: Ember.on('init', function(){
     var scaleSource = this.nearestWithProperty('isScaleSource');
     this.set('scaleSource', scaleSource);
-  }.on('init'),
+  }),
 });

--- a/addon/mixins/graph-selectable-graphic.js
+++ b/addon/mixins/graph-selectable-graphic.js
@@ -42,7 +42,7 @@ export default Ember.Mixin.create({
     @method _updateGraphSelected
     @private
   */
-  _updateGraphSelected: function() {
+  _updateGraphSelected: Ember.on('didInsertElement', Ember.observer('selected', function() {
     Ember.run.once(this, function(){
       var selected = this.get('selected');
       var graph = this.get('graph');
@@ -52,5 +52,5 @@ export default Ember.Mixin.create({
         graph.deselectGraphic(this);
       }
     });
-  }.observes('selected').on('didInsertElement'),
+  })),
 });

--- a/addon/utils/nf/graph-mouse-event.js
+++ b/addon/utils/nf/graph-mouse-event.js
@@ -32,9 +32,9 @@ export default GraphPosition.extend({
     @readonly
     @private
   */
-  _mousePoint: function(){
+  _mousePoint: Ember.computed('originalEvent', 'graphContentElement', function(){
     return this._getMousePoint(this.get('graphContentElement'), this.get('originalEvent'));
-  }.property('originalEvent', 'graphContentElement'),
+  }),
 
   /**
     The nf-graph-content element of the nf-graph
@@ -66,14 +66,14 @@ export default GraphPosition.extend({
     @type graph-position
     @readonly
   */
-  mousePosition: function(){
+  mousePosition: Ember.computed('mouseX', 'mouseY', 'source', 'graph', function(){
     return GraphPosition.create({
       graphX: this.get('mouseX'),
       graphY: this.get('mouseY'),
       source: this.get('source'),
       graph: this.get('graph'),
     });
-  }.property('mouseX', 'mouseY', 'source', 'graph'),
+  }),
 
   /**
     The raw data point nearest the mouse.graphX position
@@ -81,11 +81,11 @@ export default GraphPosition.extend({
     @type Array
     @readonly
   */
-  nearestDataPoint: function() {
+  nearestDataPoint: Ember.computed('source', 'mouse.graphX', function() {
     var mouseX = this.get('mouseX');
     var source = this.get('source');
     return source ? source.getDataNearXRange(mouseX) : undefined;
-  }.property('source', 'mouse.graphX'),
+  }),
 
   /**
     The x domain value at the nearest data point to the mouse position
@@ -93,11 +93,11 @@ export default GraphPosition.extend({
     @property x
     @readonly
   */
-  x: function() {
+  x: Ember.computed('nearestDataPoint', function() {
     var nearestDataPoint = this.get('nearestDataPoint');
     this._x =  nearestDataPoint ? nearestDataPoint[0] : undefined;
     return this._x;
-  }.property('nearestDataPoint'),
+  }),
 
   /**
     The y domain value at the nearest data point to the mouse position
@@ -105,11 +105,11 @@ export default GraphPosition.extend({
     @property y
     @readonly
   */
-  y: function() {
+  y: Ember.computed('nearestDataPoint', function() {
     var nearestDataPoint = this.get('nearestDataPoint');
     this._y = nearestDataPoint ? nearestDataPoint[1] : undefined;
     return this._y;
-  }.property('nearestDataPoint'),
+  }),
 
   /**
     The data carried by the nearest data point to the mouse position

--- a/addon/utils/nf/graph-position.js
+++ b/addon/utils/nf/graph-position.js
@@ -25,7 +25,7 @@ export default Ember.Object.extend({
     @property graphX
     @type Number
   */
-  graphX: function(key, value) {
+  graphX: Ember.computed('x', 'xScale', function(key, value) {
     if(arguments.length > 1) {
       this._graphX = value;
     } else {
@@ -36,14 +36,14 @@ export default Ember.Object.extend({
       }
     }
     return this._graphX || NaN;
-  }.property('x', 'xScale'),
+  }),
 
   /**
     The y position relative to graph
     @property graphY
     @type Number
   */
-  graphY: function(key, value) {
+  graphY: Ember.computed('y', 'yScale', function(key, value) {
     if(arguments.length > 1) {
       this._graphY = value;
     } else {
@@ -54,14 +54,14 @@ export default Ember.Object.extend({
       }
     }
     return this._graphY || NaN;
-  }.property('y', 'yScale'),
+  }),
 
   /**
     The x domain value
     @property x
     @type Number
   */
-  x: function(key, value) {
+  x: Ember.computed('graphX', 'xScale', function(key, value) {
     if(arguments.length > 1) {
       this._x = value;
     } else {
@@ -72,14 +72,14 @@ export default Ember.Object.extend({
       } 
     }
     return this._x || 0;
-  }.property('graphX', 'xScale'),
+  }),
 
   /**
     The y domain value
     @property y
     @type Number
   */
-  y: function(key, value) {
+  y: Ember.computed('graphY', 'yScale', function(key, value) {
     if(arguments.length > 1) {
       this._y = value;
     } else {
@@ -90,35 +90,35 @@ export default Ember.Object.extend({
       } 
     }
     return this._y || 0;
-  }.property('graphY', 'yScale'),
+  }),
 
   /**
     The x position relative to the document
     @property pageX
     @type Number
   */
-  pageX: function(){
+  pageX: Ember.computed('graphX', 'graphOffset', 'graphContentX', function(){
     var offset = this.get('graphOffset');
     if(offset) {
       var graphX = this.get('graphX') || 0;
       var graphContentX = this.get('graphContentX') || 0;
       return offset.left + graphX + graphContentX;
     }
-  }.property('graphX', 'graphOffset', 'graphContentX'),
+  }),
 
   /**
     The y position relative to the document
     @property pageY
     @type Number
   */
-  pageY: function(){
+  pageY: Ember.computed('graphY', 'graphOffset', 'graphContentY', function(){
     var offset = this.get('graphOffset');
     if(offset) {
       var graphY = this.get('graphY') || 0;
       var graphContentY = this.get('graphContentY') || 0;
       return offset.top + graphY + graphContentY;
     }
-  }.property('graphY', 'graphOffset', 'graphContentY'),
+  }),
 
   /**
     The x scale from either the source or graph used to calculate positions
@@ -126,9 +126,9 @@ export default Ember.Object.extend({
     @type d3.scale
     @readonly
   */
-  xScale: function(){
+  xScale: Ember.computed('graph.xScale', 'source.xScale', function(){
     return this.get('source.xScale') || this.get('graph.xScale');
-  }.property('graph.xScale', 'source.xScale'),
+  }),
 
   /**
     The y scale from either the source or graph used to calculate positions
@@ -136,9 +136,9 @@ export default Ember.Object.extend({
     @type d3.scale
     @readonly
   */
-  yScale: function(){
+  yScale: Ember.computed('graph.yScale', 'source.yScale', function(){
     return this.get('source.yScale') || this.get('graph.yScale');
-  }.property('graph.yScale', 'source.yScale'),
+  }),
 
   /**
     The JQuery offset of the graph element
@@ -146,13 +146,13 @@ export default Ember.Object.extend({
     @type Object
     @readonly
   */
-  graphOffset: function(){
+  graphOffset: Ember.computed('graph', function(){
     var graph = this.get('graph');
     if(graph) {
       var content = graph.$('.nf-graph-content');
       return content ? content.offset() : undefined;
     }
-  }.property('graph'),
+  }),
 
   /**
     The center point at x. Use in case of requiring a center point 
@@ -160,7 +160,7 @@ export default Ember.Object.extend({
     @property centerX
     @type Number
   */
-  centerX: function(){
+  centerX: Ember.computed('xScale', 'graphX', function(){
     var scale = this.get('xScale');
     var graphX = this.get('graphX');
     if(scale && scale.rangeBand) {
@@ -168,7 +168,7 @@ export default Ember.Object.extend({
       return graphX + (rangeBand / 2);
     }
     return graphX;
-  }.property('xScale', 'graphX'),
+  }),
 
   /**
     The center point at y. Use in case of requiring a center point 
@@ -176,7 +176,7 @@ export default Ember.Object.extend({
     @property centerY
     @type Number
   */
-  centerY: function(){
+  centerY: Ember.computed('yScale', 'graphY', function(){
     var scale = this.get('yScale');
     var graphY = this.get('graphY');
     if(scale && scale.rangeBand) {
@@ -184,7 +184,7 @@ export default Ember.Object.extend({
       return graphY + (rangeBand / 2);
     }
     return graphY;
-  }.property('yScale', 'graphY'),
+  }),
 
   /**
     The x position of the nf-graph-content within the nf-graph

--- a/addon/utils/nf/scroll-area-action-context.js
+++ b/addon/utils/nf/scroll-area-action-context.js
@@ -60,9 +60,9 @@ export default Ember.Object.extend({
     @type Number
     @readonly
   */
-  scrollTopMax: function(){
+  scrollTopMax: Ember.computed('outerHeight', 'scrollHeight', function(){
     return this.get('scrollHeight') - this.get('outerHeight');
-  }.property('outerHeight', 'scrollHeight'),
+  }),
 
   /**
     The calculated percentage, in decimals, of content scrolled.
@@ -70,9 +70,9 @@ export default Ember.Object.extend({
     @type Number
     @readonly
   */
-  scrollTopPercentage: function() {
+  scrollTopPercentage: Ember.computed('scrollTop', 'scrollTopMax', function() {
     return this.get('scrollTop') / this.get('scrollTopMax');
-  }.property('scrollTop', 'scrollTopMax'),
+  }),
   
   /**
     The calculated maximum value for scrollTop in pixels.
@@ -80,9 +80,9 @@ export default Ember.Object.extend({
     @type Number
     @readonly
   */
-  scrollLeftMax: function(){
+  scrollLeftMax: Ember.computed('outerWidth', 'scrollWidth', function(){
     return this.get('scrollWidth') - this.get('outerWidth');
-  }.property('outerWidth', 'scrollWidth'),
+  }),
 
   /**
     The calculated percentage, in decimals, of content scrolled.
@@ -90,9 +90,9 @@ export default Ember.Object.extend({
     @type Number
     @readonly
   */
-  scrollLeftPercentage: function() {
+  scrollLeftPercentage: Ember.computed('scrollLeft', 'scrollLeftMax', function() {
     return this.get('scrollLeft') / this.get('scrollLeftMax');
-  }.property('scrollLeft', 'scrollLeftMax'),
+  }),
 
   /**
     The component that fired the event

--- a/addon/utils/nf/tracked-array-property.js
+++ b/addon/utils/nf/tracked-array-property.js
@@ -7,7 +7,7 @@ function trackedArrayProperty(arraySourceProp, trackByProp, backingField) {
 
   backingField = backingField || '_%@_trackBy_%@'.fmt(arraySourceProp, trackByProp);
 
-  return function(){
+  return Ember.computed(arraySourceDependency, function(){
     var array = this.get(backingField);
 
     if(!Ember.isArray(array)){
@@ -62,7 +62,7 @@ function trackedArrayProperty(arraySourceProp, trackByProp, backingField) {
     this.set(backingField, array);
     
     return array;
-  }.property(arraySourceDependency);
+  });
 }
 
 export default trackedArrayProperty;

--- a/app/components/nf-area-stack.js
+++ b/app/components/nf-area-stack.js
@@ -40,9 +40,9 @@ export default Ember.Component.extend({
     @type Array
     @readonly
   */
-  areas: function(){
+  areas: Ember.computed(function(){
     return [];
-  }.property(),
+  }),
 
   /**
     Registers an area component with this stack. Also links areas to one

--- a/app/components/nf-area.js
+++ b/app/components/nf-area.js
@@ -54,20 +54,20 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
     */
     nextArea: null,
 
-    _checkForAreaStackParent: function() {
+    _checkForAreaStackParent: Ember.on('init', function() {
       var stack = this.nearestWithProperty('isAreaStack');
       if(stack) {
         stack.registerArea(this);
         this.set('stack', stack);
       }
-    }.on('init'),
+    }),
 
-    _unregister: function(){
+    _unregister: Ember.on('willDestroyElement', function(){
       var stack = this.get('stack', stack);
       if(stack) {
         stack.unregisterArea(this);
       }
-    }.on('willDestroyElement'),
+    }),
 
     /**
       The computed set of next y values to use for the "bottom" of the graphed area.
@@ -77,7 +77,7 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Array
       @readonly
     */
-    nextYData: function(){
+    nextYData: Ember.computed('renderedData.@each', 'nextArea.renderedData.@each', function(){
       var renderedData = this.get('renderedData');
       var nextData = this.get('nextArea.renderedData') || [];
         
@@ -90,7 +90,7 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       }
 
       return result;
-    }.property('renderedData.@each', 'nextArea.renderedData.@each'),
+    }),
 
     /**
       The current rendered data "zipped" together with the nextYData.
@@ -98,12 +98,12 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Array
       @readonly
     */
-    areaData: function(){
+    areaData: Ember.computed('renderedData.@each', 'nextYData.@each', function(){
       var nextYData = this.get('nextYData');
       return this.get('renderedData').map(function(r, i) {
         return [r[0], r[1], nextYData[i]];
       });
-    }.property('renderedData.@each', 'nextYData.@each'),
+    }),
 
 
     /**
@@ -112,12 +112,12 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type Function
       @readonly
     */
-    areaFn: function(){
+    areaFn: Ember.computed('xScale', 'yScale', 'interpolator', function(){
       var xScale = this.get('xScale');
       var yScale = this.get('yScale');
       var interpolator = this.get('interpolator');
       return this.createAreaFn(xScale, yScale, interpolator);
-    }.property('xScale', 'yScale', 'interpolator'),
+    }),
 
     /**
       The SVG path data for the area
@@ -125,9 +125,9 @@ export default Ember.Component.extend(HasGraphParent, RegisteredGraphic, DataGra
       @type String
       @readonly
     */
-    d: function(){
+    d: Ember.computed('areaData', 'areaFn', function(){
       return this.get('areaFn')(this.get('areaData'));
-    }.property('areaData', 'areaFn'),
+    }),
 
     click: function(){
       if(this.get('selectable')) {

--- a/app/components/nf-bars-group.js
+++ b/app/components/nf-bars-group.js
@@ -12,9 +12,9 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, {
   groupOuterPadding: 0,
 
   // either b-arses or fat, stupid hobbitses
-  barses: function(){
+  barses: Ember.computed(function(){
     return [];
-  }.property(),
+  }),
 
   registerBars: function(bars) {
     var barses = this.get('barses');
@@ -31,25 +31,31 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, {
     }
   },
 
-  groupWidth: function(){
+  groupWidth: Ember.computed('xScale', function(){
     var xScale = this.get('xScale');
     return xScale && xScale.rangeBand ? xScale.rangeBand() : NaN;
-  }.property('xScale'),
+  }),
 
-  barsDomain: function(){
+  barsDomain: Ember.computed('barses.[]', function(){
     var len = this.get('barses.length') || 0;
     return d3.range(len);
-  }.property('barses.[]'),
+  }),
 
-  barScale: function(){
-    var barsDomain = this.get('barsDomain');
-    var groupWidth = this.get('groupWidth');
-    var groupPadding = this.get('groupPadding');
-    var groupOuterPadding = this.get('groupOuterPadding');
-    return d3.scale.ordinal()
-      .domain(barsDomain)
-      .rangeBands([0, groupWidth], groupPadding, groupOuterPadding);
-  }.property('groupWidth', 'barsDomain.[]', 'groupPadding', 'groupOuterPadding'),
+  barScale: Ember.computed(
+    'groupWidth',
+    'barsDomain.[]',
+    'groupPadding',
+    'groupOuterPadding',
+    function(){
+      var barsDomain = this.get('barsDomain');
+      var groupWidth = this.get('groupWidth');
+      var groupPadding = this.get('groupPadding');
+      var groupOuterPadding = this.get('groupOuterPadding');
+      return d3.scale.ordinal()
+        .domain(barsDomain)
+        .rangeBands([0, groupWidth], groupPadding, groupOuterPadding);
+    }
+  ),
 
   barsWidth: function() {
     var scale = this.get('barScale');

--- a/app/components/nf-brush-selection.js
+++ b/app/components/nf-brush-selection.js
@@ -40,9 +40,9 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, {
     }
   },
 
-  _autoWireUpChanged: function(){
+  _autoWireUpChanged: Ember.on('didInsertElement', Ember.observer('autoWireUp', function(){
     Ember.run.once(this, this._wireToGraph);
-  }.observes('autoWireUp').on('didInsertElement'),
+  })),
 
   _updateLeftText: function(){
     var root = d3.select(this.element);
@@ -80,9 +80,12 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, {
       attr('height', height);
   },
 
-  _onLeftChange: function(){
-    Ember.run.once(this, this._updateLeftText);
-  }.observes('left', 'graphHeight', 'textPadding').on('didInsertElement'),
+  _onLeftChange: Ember.on(
+    'didInsertElement',
+    Ember.observer('left', 'graphHeight', 'textPadding', function(){
+      Ember.run.once(this, this._updateLeftText);
+    })
+  ),
 
   _updateRightText: function(){
     var root = d3.select(this.element);
@@ -121,45 +124,48 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, {
       attr('height', height);
   },
 
-  _onRightChange: function(){
-    Ember.run.once(this, this._updateRightText);
-  }.observes('right', 'graphHeight', 'graphWidth', 'textPadding').on('didInsertElement'),
+  _onRightChange: Ember.on(
+    'didInsertElement',
+    Ember.observer('right', 'graphHeight', 'graphWidth', 'textPadding', function(){
+      Ember.run.once(this, this._updateRightText);
+    })
+  ),
 
-  leftDisplay: function(){
+  leftDisplay: Ember.computed('left', 'formatter', function(){
     var formatter = this.get('formatter');
     var left = this.get('left');
     return formatter ? formatter(left) : left;
-  }.property('left', 'formatter'),
+  }),
 
-  rightDisplay: function(){
+  rightDisplay: Ember.computed('right', 'formatter', function(){
     var formatter = this.get('formatter');
     var right = this.get('right');
     return formatter ? formatter(right) : right;
-  }.property('right', 'formatter'),
+  }),
 
-  isVisible: function(){
+  isVisible: Ember.computed('left', 'right', function(){
     var left = +this.get('left');
     var right = +this.get('right');
     return left === left && right === right;
-  }.property('left', 'right'),
+  }),
 
-  leftX: function() {
+  leftX: Ember.computed('xScale', 'left', function() {
     var left = this.get('left') || 0;
     var scale = this.get('xScale');
     return scale ? scale(left) : 0; 
-  }.property('xScale', 'left'),
+  }),
 
-  rightX: function() {
+  rightX: Ember.computed('xScale', 'right', function() {
     var right = this.get('right') || 0;
     var scale = this.get('xScale');
     return scale ? scale(right) : 0;
-  }.property('xScale', 'right'),
+  }),
 
   graphWidth: Ember.computed.alias('graph.graphWidth'),
   
   graphHeight: Ember.computed.alias('graph.graphHeight'),
 
-  rightWidth: function() {
+  rightWidth: Ember.computed('rightX', 'graphWidth', function() {
     return (this.get('graphWidth') - this.get('rightX')) || 0;
-  }.property('rightX', 'graphWidth'),
+  }),
 });

--- a/app/components/nf-crosshair.js
+++ b/app/components/nf-crosshair.js
@@ -64,11 +64,11 @@ export default Ember.Component.extend(HasGraphParent, {
     this.set('isVisible', false);
   },
 
-  _setupBindings: function() {
+  _setupBindings: Ember.observer('graph.content', function() {
     var content = this.get('graph.content');
     if(content) {
       content.on('didHoverChange', this, this.didContentHoverChange);
       content.on('didHoverEnd', this, this.didContentHoverEnd);
     }
-  }.observes('graph.content'),
+  }),
 });

--- a/app/components/nf-dot.js
+++ b/app/components/nf-dot.js
@@ -51,12 +51,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  cx: function(){
+  cx: Ember.computed('x', 'xScale', 'hasX', function(){
     var x = this.get('x');
     var xScale = this.get('xScale');
     var hasX = this.get('hasX');
     return hasX && xScale ? xScale(x) : -1;
-  }.property('x', 'xScale', 'hasX'),
+  }),
 
   /**
     The computed center y coordinate of the circle
@@ -65,12 +65,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  cy: function() {
+  cy: Ember.computed('y', 'yScale', 'hasY', function() {
     var y = this.get('y');
     var yScale = this.get('yScale');
     var hasY = this.get('hasY');
     return hasY && yScale ? yScale(y) : -1;
-  }.property('y', 'yScale', 'hasY'),
+  }),
 
   /**
     Toggles the visibility of the dot. If x or y are

--- a/app/components/nf-graph-content.js
+++ b/app/components/nf-graph-content.js
@@ -18,10 +18,10 @@ export default Ember.Component.extend(HasGraphParent, {
 
   attributeBindings: ['transform', 'clip-path'],
 
-  'clip-path': function(){
+  'clip-path': Ember.computed('graph.contentClipPathId', function(){
     var clipPathId = this.get('graph.contentClipPathId');
     return 'url(\'#%@\')'.fmt(clipPathId);
-  }.property('graph.contentClipPathId'),
+  }),
 
   /**
     The SVG transform for positioning the graph content
@@ -29,9 +29,9 @@ export default Ember.Component.extend(HasGraphParent, {
     @type String
     @readonly
   */
-  transform: function(){
+  transform: Ember.computed('x', 'y', function(){
     return 'translate(%@ %@)'.fmt(this.get('x'), this.get('y'));
-  }.property('x', 'y'),
+  }),
 
   /**
     The x position of the graph content
@@ -72,7 +72,7 @@ export default Ember.Component.extend(HasGraphParent, {
     @type Array
     @readonly
   */
-  gridLanes: function () {
+  gridLanes: Ember.computed('graph.yAxis.ticks', 'width', 'height', function () {
     var ticks = this.get('graph.yAxis.ticks');
     var width = this.get('width');
     var height = this.get('height');
@@ -103,7 +103,7 @@ export default Ember.Component.extend(HasGraphParent, {
     }, []);
 
     return lanes;
-  }.property('graph.yAxis.ticks', 'width', 'height'),
+  }),
 
   /**
     The name of the hoverChange action to fire

--- a/app/components/nf-horizontal-line.js
+++ b/app/components/nf-horizontal-line.js
@@ -32,11 +32,11 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  lineY: function(){
+  lineY: Ember.computed('y', 'yScale', function(){
     var y = this.get('y');
     var yScale = this.get('yScale');
     return yScale ? yScale(y) : -1;
-  }.property('y', 'yScale'),
+  }),
 
   /**
     The left x coordinate of the line

--- a/app/components/nf-line.js
+++ b/app/components/nf-line.js
@@ -44,12 +44,12 @@ export default Ember.Component.extend(HasGraphParent, DataGraphic, SelectableGra
     @private
     @return {String} an SVG path data string
   */
-  lineFn: function(){
+  lineFn: Ember.computed('xScale', 'yScale', 'interpolator', function(){
     var xScale = this.get('xScale');
     var yScale = this.get('yScale');
     var interpolator = this.get('interpolator');
     return this.createLineFn(xScale, yScale, interpolator);
-  }.property('xScale', 'yScale', 'interpolator'),
+  }),
 
   /**
     The SVG path data string to render the line
@@ -58,20 +58,20 @@ export default Ember.Component.extend(HasGraphParent, DataGraphic, SelectableGra
     @private
     @readonly
   */
-  d: function(){
+  d: Ember.computed('renderedData.@each', 'lineFn', function(){
     var renderedData = this.get('renderedData');
     var lineFn = this.get('lineFn');
     return lineFn(renderedData);
-  }.property('renderedData.@each', 'lineFn'),
+  }),
 
   /**
     Event handler to toggle the `selected` property on click
     @method _toggleSelected
     @private
   */
-  _toggleSelected: function(){
+  _toggleSelected: Ember.on('click', function(){
     if(this.get('selectable')) {
       this.toggleProperty('selected');
     }
-  }.on('click'),
+  }),
 });

--- a/app/components/nf-plot.js
+++ b/app/components/nf-plot.js
@@ -62,12 +62,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  rangeX: function(){
+  rangeX: Ember.computed('x', 'xScale', function(){
     var xScale = this.get('xScale');
     var x = this.get('x');
     var hasX = this.get('hasX');
     return (hasX && xScale ? xScale(x) : 0) || 0;
-  }.property('x', 'xScale'),
+  }),
 
   /**
     The calculated y coordinate
@@ -75,12 +75,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  rangeY: function(){
+  rangeY: Ember.computed('y', 'yScale', function(){
     var yScale = this.get('yScale');
     var y = this.get('y');
     var hasY = this.get('hasY');
     return (hasY && yScale ? yScale(y) : 0) || 0;
-  }.property('y', 'yScale'),
+  }),
 
   /**
     The SVG transform of the component's `<g>` tag.
@@ -88,9 +88,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type String
     @readonly
   */
-  transform: function(){
+  transform: Ember.computed('rangeX', 'rangeY', function(){
     return 'translate(%@ %@)'.fmt(this.get('rangeX'), this.get('rangeY'));
-  }.property('rangeX', 'rangeY'),
+  }),
 
   data: null,
 

--- a/app/components/nf-plots.js
+++ b/app/components/nf-plots.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend(HasGraphParent, DataGraphic, RequireScaleS
     @readonly
     @private
   */
-  plotData: function(){
+  plotData: Ember.computed('renderedData.@each', function(){
     var renderedData = this.get('renderedData');
     if(renderedData && Ember.isArray(renderedData)) {
       return renderedData.map(function(d) {
@@ -34,7 +34,7 @@ export default Ember.Component.extend(HasGraphParent, DataGraphic, RequireScaleS
         };
       });
     }
-  }.property('renderedData.@each'),
+  }),
 
 
   actions: {

--- a/app/components/nf-range-marker.js
+++ b/app/components/nf-range-marker.js
@@ -70,11 +70,11 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  x: function(){
+  x: Ember.computed('xMin', 'xScale', function(){
     var xScale = this.get('xScale');
     var xMin = this.get('xMin');
     return xScale(xMin);
-  }.property('xMin', 'xScale'),
+  }),
 
   /**
     The computed width of the range marker.
@@ -82,12 +82,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  width: function() {
+  width: Ember.computed('xScale', 'xMin', 'xMax', function() {
     var xScale = this.get('xScale');
     var xMax = this.get('xMax');
     var xMin = this.get('xMin');
     return xScale(xMax) - xScale(xMin);
-  }.property('xScale', 'xMin', 'xMax'),
+  }),
 
   /**
     The computed y position of the range marker.
@@ -95,23 +95,30 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  y: function() {
-    var orient = this.get('container.orient');
-    var prevBottom = this.get('prevMarker.bottom');
-    var prevY = this.get('prevMarker.y');
-    var graphHeight = this.get('graph.graphHeight');
-    var totalHeight = this.get('totalHeight');
+  y: Ember.computed(
+    'container.orient',
+    'prevMarker.bottom',
+    'prevMarker.y',
+    'graph.graphHeight',
+    'totalHeight',
+    function() {
+      var orient = this.get('container.orient');
+      var prevBottom = this.get('prevMarker.bottom');
+      var prevY = this.get('prevMarker.y');
+      var graphHeight = this.get('graph.graphHeight');
+      var totalHeight = this.get('totalHeight');
 
-    prevBottom = prevBottom || 0;
+      prevBottom = prevBottom || 0;
 
-    if(orient === 'bottom') {
-      return (prevY || graphHeight) - totalHeight;
+      if(orient === 'bottom') {
+        return (prevY || graphHeight) - totalHeight;
+      }
+
+      if(orient === 'top') {
+        return prevBottom;
+      }
     }
-
-    if(orient === 'top') {
-      return prevBottom;
-    }
-  }.property('container.orient', 'prevMarker.bottom', 'prevMarker.y', 'graph.graphHeight', 'totalHeight'),
+  ),
 
   /**
     The computed total height of the range marker including its margins.
@@ -119,12 +126,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  totalHeight: function() {
+  totalHeight: Ember.computed('height', 'marginTop', 'marginBottom', function() {
     var height = this.get('height');
     var marginTop = this.get('marginTop');
     var marginBottom = this.get('marginBottom');
     return height + marginTop + marginBottom;
-  }.property('height', 'marginTop', 'marginBottom'),
+  }),
 
   /**
     The computed bottom of the range marker, not including the bottom margin.
@@ -132,11 +139,11 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  bottom: function(){
+  bottom: Ember.computed('y', 'totalHeight', function(){
     var y = this.get('y');
     var totalHeight = this.get('totalHeight');
     return y + totalHeight;
-  }.property('y', 'totalHeight'),
+  }),
 
   /**
     The computed SVG transform of the range marker container
@@ -144,10 +151,10 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type String
     @readonly
   */
-  transform: function(){ 
+  transform: Ember.computed('y', function(){ 
     var y = this.get('y');
     return 'translate(0 %@)'.fmt(y || 0);
-  }.property('y'),
+  }),
 
   /**
     The computed SVG transform fo the range marker label container.
@@ -155,10 +162,10 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type String
     @readonly
   */
-  labelTransform: function(){
+  labelTransform: Ember.computed('x', function(){
     var x = this.get('x');
     return 'translate(%@ 0)'.fmt(x || 0);
-  }.property('x'),
+  }),
 
   /**
     Initialization function that registers the range marker with its parent 
@@ -166,18 +173,18 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method _setup
     @private
   */
-  _setup: function(){
+  _setup: Ember.on('init', function(){
     var container = this.nearestWithProperty('isRangeMarkerContainer');
     container.registerMarker(this);
     this.set('container', container);
-  }.on('init'),
+  }),
 
   /**
     Unregisters the range marker from its parent when the range marker is destroyed.
     @method _unregister
     @private
   */
-  _unregister: function() {
+  _unregister: Ember.on('willDestroyElement', function() {
     this.get('container').unregisterMarker(this);
-  }.on('willDestroyElement')
+  })
 });

--- a/app/components/nf-range-markers.js
+++ b/app/components/nf-range-markers.js
@@ -47,9 +47,9 @@ export default Ember.Component.extend(HasGraphParent, {
     @type Array
     @readonly
   */
-  markers: function() {
+  markers: Ember.computed(function() {
     return [];
-  }.property(),
+  }),
 
   /**
     Adds the passed marker to the `markers` list, and sets the `prevMarker` and `nextMarker`

--- a/app/components/nf-right-tick.js
+++ b/app/components/nf-right-tick.js
@@ -45,9 +45,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  isVisible: function(){
+  isVisible: Ember.computed('y', function(){
     return !isNaN(this.get('y'));
-  }.property('y'),
+  }),
 
   /**
     The calculated y coordinate of the tick
@@ -55,7 +55,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  y: function() {
+  y: Ember.computed('value', 'yScale', 'graph.paddingTop', function() {
     var value = this.get('value');
     var yScale = this.get('yScale');
     var paddingTop = this.get('graph.paddingTop');
@@ -64,7 +64,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
       vy = yScale(value) || 0;
     }
     return vy + paddingTop;
-  }.property('value', 'yScale', 'graph.paddingTop'),
+  }),
 
   /**
     The SVG transform used to render the tick
@@ -73,11 +73,11 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  transform: function(){
+  transform: Ember.computed('y', 'graph.width', function(){
     var y = this.get('y');
     var graphWidth = this.get('graph.width');
     return 'translate(%@ %@)'.fmt(graphWidth - 6, y - 3);
-  }.property('y', 'graph.width'),
+  }),
 
   /**
     performs the D3 transition to move the tick to the proper position.
@@ -97,9 +97,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method _triggerTransition
     @private
   */
-  _triggerTransition: function(){
+  _triggerTransition: Ember.on('init', Ember.observer('value', function(){
     Ember.run.scheduleOnce('afterRender', this, this._transitionalUpdate);
-  }.observes('value').on('init'),
+  })),
 
   /**
     Updates the tick position without a transition.
@@ -117,18 +117,18 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method _triggerNonTransitionalUpdate
     @private
   */
-  _triggerNonTransitionalUpdate: function(){
+  _triggerNonTransitionalUpdate: Ember.observer('graph.width', function(){
     Ember.run.scheduleOnce('afterRender', this, this._nonTransitionalUpdate);
-  }.observes('graph.width'),
+  }),
 
   /**
     Gets the elements required to do the d3 transitions
     @method _getElements
     @private
   */
-  _getElements: function(){
+  _getElements: Ember.on('didInsertElement', function(){
     var g = d3.select(this.$()[0]);
     var path = g.selectAll('path').data([0]);
     this.set('path', path);
-  }.on('didInsertElement')
+  })
 });

--- a/app/components/nf-scroll-area.js
+++ b/app/components/nf-scroll-area.js
@@ -55,16 +55,16 @@ export default Ember.Component.extend({
     @property scrollTopPercentage
     @type {Number}
   */
-  scrollTopPercentage: function(key, value) {
+  scrollTopPercentage: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._scrollTopPercentage = value;
     }
     return this._scrollTopPercentage;
-  }.property().volatile(),
+  }).volatile(),
 
   _childMutationObserver: null,
 
-  _setupChildMutationObserver: function() {
+  _setupChildMutationObserver: Ember.on('didInsertElement', function() {
     var handler = function(e) {
       var context = this.createActionContext(e);
       this.sendAction('childrenChangedAction', context);   
@@ -76,21 +76,21 @@ export default Ember.Component.extend({
 
     // trigger initial event
     handler();
-  }.on('didInsertElement'),
+  }),
 
-  _teardownChildMutationObserver: function(){
+  _teardownChildMutationObserver: Ember.on('willDestroyElement', function(){
     if(this._childMutationObserver) {
       this._childMutationObserver.disconnect();
     }
-  }.on('willDestroyElement'),
+  }),
 
-  _updateScrollTop: function(){
+  _updateScrollTop: Ember.on('didInsertElement', Ember.observer('scrollTopPercentage', function(){
     var element = this.get('element');
     if(element) {
       var scrollTop = this.get('scrollTopPercentage') * (element.scrollHeight - this.$().outerHeight());
       this.set('scrollTop', scrollTop);
     }
-  }.observes('scrollTopPercentage').on('didInsertElement'),
+  })),
 
   /**
     Gets or sets the scrollTop of the area
@@ -98,18 +98,18 @@ export default Ember.Component.extend({
     @type {Number}
     @default 0
   */
-  scrollTop: function(key, value){
+  scrollTop: Ember.computed(function(key, value){
     if(arguments.length > 1) {
       this._scrollTop = value;
     }
     return this._scrollTop;
-  }.property().volatile(),
+  }).volatile(),
 
-  _updateScroll: function(){
+  _updateScroll: Ember.on('didInsertElement', Ember.observer('scrollTop', function(){
     if(this.get('element')) {
       this.$().scrollTop(this.get('scrollTop'));
     }
-  }.observes('scrollTop').on('didInsertElement'),
+  })),
 
   /**
     The optional action data to send with the action contextl
@@ -162,19 +162,19 @@ export default Ember.Component.extend({
     return ScrollAreaActionContext.create(context);
   },
 
-  _setupElement: function() {
+  _setupElement: Ember.on('didInsertElement', function() {
     var elem = this.get('element');
     if(elem) {
       elem.addEventListener('scroll', this._onScroll.bind(this));
       elem.addEventListener('resize', this._onResize.bind(this));
     }
-  }.on('didInsertElement'),
+  }),
 
-  _unsubscribeEvents: function(){
+  _unsubscribeEvents: Ember.on('willDestroyElement', function(){
     var elem = this.get('element');
     if(elem) {
       elem.removeEventListener('scroll', this._onScroll);
       elem.removeEventListener('resize', this._onResize);
     }
-  }.on('willDestroyElement'),
+  }),
 });

--- a/app/components/nf-selection-box.js
+++ b/app/components/nf-selection-box.js
@@ -57,45 +57,45 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @property x0
     @type Number
   */
-  x0: function(){
+  x0: Ember.computed('xMin', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('xMin'));
-  }.property('xMin', 'xScale'),
+  }),
 
   /**
     The x pixel position of xMax
     @property x1
     @type Number
   */
-  x1: function(){
+  x1: Ember.computed('xMax', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('xMax'));
-  }.property('xMax', 'xScale'),
+  }),
 
   /**
     The y pixel position of yMin
     @property y0
     @type Number
   */
-  y0: function(){
+  y0: Ember.computed('yMin', 'yScale', function(){
     return normalizeScale(this.get('yScale'), this.get('yMin'));
-  }.property('yMin', 'yScale'),
+  }),
 
   /**
     The y pixel position of yMax
     @property y1
     @type Number
   */
-  y1: function(){
+  y1: Ember.computed('yMax', 'yScale', function(){
     return normalizeScale(this.get('yScale'), this.get('yMax'));
-  }.property('yMax', 'yScale'),
+  }),
 
   /**
     The SVG path string for the box's rectangle.
     @property rectPath
     @type String
   */
-  rectPath: function(){
+  rectPath: Ember.computed('x0', 'x1', 'y0', 'y1', function(){
     return 'M%@1,%@2 L%@1,%@4 L%@3,%@4 L%@3,%@2 L%@1,%@2'.fmt(this.get('x0'), this.get('y0'), this.get('x1'), this.get('y1'));
-  }.property('x0', 'x1', 'y0', 'y1'),
+  }),
 
   /**
     Updates the position of the box with a transition
@@ -122,13 +122,13 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @method updatePosition
     @private
   */
-  updatePosition: function(){
+  updatePosition: Ember.observer('xMin', 'xMax', 'yMin', 'yMax', function(){
     Ember.run.once(this, this.doUpdatePosition);
-  }.observes('xMin', 'xMax', 'yMin', 'yMax'),
+  }),
 
-  staticPositionChange: function(){
+  staticPositionChange: Ember.on('didInsertElement', Ember.observer('xScale', 'yScale', function(){
     Ember.run.once(this, this.doUpdatePositionStatic);
-  }.observes('xScale', 'yScale').on('didInsertElement'),
+  })),
 
   /**
     Sets up the required d3 elements after component

--- a/app/components/nf-svg-image.js
+++ b/app/components/nf-svg-image.js
@@ -51,12 +51,12 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @type Number
     @default 0
   */
-  width: function(key, value) {
+  width: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._width = Math.max(0, +value) || 0;
     }
     return this._width;
-  }.property(),
+  }),
 
   _height: 0,
 
@@ -67,84 +67,84 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @property height
     @default null
   */
-  height: function(key, value) {
+  height: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._height = Math.max(0, +value) || 0;
     }
     return this._height;
-  }.property(),
+  }),
 
   /**
     The image source url
     @property src
     @type String
   */
-  src: function(key, value) {
+  src: Ember.computed(function(key, value) {
     //HACK: because attributeBindings doesn't currently work with namespaced attributes.
     var $elem = this.$();
     if(arguments.length > 1) {
       $elem.attr('xlink:href', value);
     }
     return $elem.attr('xlink:href');
-  }.property(),
+  }),
 
-  x0: function(){
+  x0: Ember.computed('x', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('x'));
-  }.property('x', 'xScale'),
+  }),
 
-  y0: function(){
+  y0: Ember.computed('y', 'yScale', function(){
     return normalizeScale(this.get('yScale'), this.get('y'));
-  }.property('y', 'yScale'),
+  }),
 
-  x1: function(){
+  x1: Ember.computed('xScale', 'width', 'x', function(){
     var scale = this.get('xScale');
     if(scale.rangeBands) {
       throw new Error('nf-image does not support ordinal scales');
     }
     return normalizeScale(scale, this.get('width') + this.get('x'));
-  }.property('xScale', 'width', 'x'),
+  }),
 
-  y1: function(){
+  y1: Ember.computed('yScale', 'height', 'y', function(){
     var scale = this.get('yScale');
     if(scale.rangeBands) {
       throw new Error('nf-image does not support ordinal scales');
     }
     return normalizeScale(scale, this.get('height') + this.get('y'));
-  }.property('yScale', 'height', 'y'),
+  }),
 
   /**
     The pixel value at which to plot the image.
     @property svgX
     @type Number
   */
-  svgX: function(){
+  svgX: Ember.computed('x0', 'x1', function(){
     return Math.min(this.get('x0'), this.get('x1'));
-  }.property('x0', 'x1'),
+  }),
 
   /**
     The pixel value at which to plot the image.
     @property svgY
     @type Number
   */
-  svgY: function(){
+  svgY: Ember.computed('y0', 'y1', function(){
     return Math.min(this.get('y0'), this.get('y1'));
-  }.property('y0', 'y1'),
+  }),
 
   /**
     The width, in pixels, of the image.
     @property svgWidth
     @type Number
   */
-  svgWidth: function(){
+  svgWidth: Ember.computed('x0', 'x1', function(){
     return Math.abs(this.get('x0') - this.get('x1'));
-  }.property('x0', 'x1'),
+  }),
 
   /**
     The height, in pixels of the image.
     @property svgHeight
     @type Number
   */
-  svgHeight: function(){
+  svgHeight: Ember.computed('y0', 'y1', function(){
     return Math.abs(this.get('y0') - this.get('y1'));
-  }.property('y0', 'y1'),
+  }),
 });

--- a/app/components/nf-svg-line.js
+++ b/app/components/nf-svg-line.js
@@ -59,34 +59,34 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @property svgX1
     @type Number
   */
-  svgX1: function(){
+  svgX1: Ember.computed('x1', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('x1'));
-  }.property('x1', 'xScale'),
+  }),
   
   /**
     The pixel value to plot the SVGLineElement's x2 at.
     @property svgX2
     @type Number
   */
-  svgX2: function(){
+  svgX2: Ember.computed('x2', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('x2'));
-  }.property('x2', 'xScale'),
+  }),
 
   /**
     The pixel value to plot the SVGLineElement's y1 at.
     @property svgY1
     @type Number
   */
-  svgY1: function(){
+  svgY1: Ember.computed('y1', 'yScale', function(){
     return normalizeScale(this.get('yScale'), this.get('y1'));
-  }.property('y1', 'yScale'),
+  }),
   
   /**
     The pixel value to plot the SVGLineElement's y2 at.
     @property svgY2
     @type Number
   */
-  svgY2: function(){
+  svgY2: Ember.computed('y2', 'yScale', function(){
     return normalizeScale(this.get('yScale'), this.get('y2'));
-  }.property('y2', 'yScale'),
+  }),
 });

--- a/app/components/nf-svg-path.js
+++ b/app/components/nf-svg-path.js
@@ -45,7 +45,7 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @property svgPoints
     @type Array
   */
-  svgPoints: function(){
+  svgPoints: Ember.computed('points.[]', 'xScale', 'yScale', function(){
     var points = this.get('points');
     var xScale = this.get('xScale');
     var yScale = this.get('yScale');
@@ -57,7 +57,7 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
         return [dx, dy, c];
       });
     } 
-  }.property('points.[]', 'xScale', 'yScale'),
+  }),
 
   click: function(){
     if(this.get('selectable')) {
@@ -70,7 +70,7 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @property d
     @type String
   */
-  d: function(){
+  d: Ember.computed('svgPoints', function(){
     var svgPoints = this.get('svgPoints');
     if(Ember.isArray(svgPoints) && svgPoints.length > 0) {
       return svgPoints.reduce(function(d, pt, i) {
@@ -83,5 +83,5 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     } else {
       return 'M0,0';
     }
-  }.property('svgPoints'),
+  }),
 });

--- a/app/components/nf-svg-rect.js
+++ b/app/components/nf-svg-rect.js
@@ -46,12 +46,12 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @type Number
     @default 0
   */
-  width: function(key, value) {
+  width: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._width = +value;
     }
     return this._width;
-  }.property(),
+  }),
 
   _height: 0,
 
@@ -64,19 +64,19 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
     @type Number
     @default 0
   */
-  height: function(key, value) {
+  height: Ember.computed(function(key, value) {
     if(arguments.length > 1) {
       this._height = +value;
     }
     return this._height;
-  }.property(),
+  }),
 
   /**
     The x value of the bottom right corner of the rectangle.
     @property x1
     @type Number
   */
-  x1: function(){
+  x1: Ember.computed('width', 'x', 'xScale', function(){
     var xScale = this.get('xScale');
     var w = this.get('width');
     var x = this.get('x');
@@ -89,14 +89,14 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
       x = +x || 0;
       return normalizeScale(xScale, w + x);
     }
-  }.property('width', 'x', 'xScale'),
+  }),
 
   /**
     The y value of the bottom right corner of the rectangle
     @property y1
     @type Number
   */
-  y1: function(){
+  y1: Ember.computed('height', 'y', 'yScale', function(){
     var yScale = this.get('yScale');
     var h = this.get('height');
     var y = this.get('y');
@@ -109,38 +109,38 @@ export default Ember.Component.extend(HasGraphParent, RequiresScaleSource, Selec
       y = +y || 0;
       return normalizeScale(yScale, h + y);
     }
-  }.property('height', 'y', 'yScale'),
+  }),
 
   /**
     The x value of the top right corner of the rectangle
     @property x0
     @type Number
   */
-  x0: function(){
+  x0: Ember.computed('x', 'xScale', function(){
     return normalizeScale(this.get('xScale'), this.get('x'));
-  }.property('x', 'xScale'),
+  }),
 
   /**
     The y value of the top right corner of the rectangle.
     @property y0
     @type Number
   */
-  y0: function() {
+  y0: Ember.computed('y', 'yScale', function() {
     return normalizeScale(this.get('yScale'), this.get('y'));
-  }.property('y', 'yScale'),
+  }),
 
   /**
     The SVG path data for the rectangle
     @property d
     @type String
   */
-  d: function(){
+  d: Ember.computed('x0', 'y0', 'x1', 'y1', function(){
     var x0 = this.get('x0');
     var y0 = this.get('y0');
     var x1 = this.get('x1');
     var y1 = this.get('y1');
     return 'M%@1,%@2 L%@1,%@4 L%@3,%@4 L%@3,%@2 L%@1,%@2'.fmt(x0, y0, x1, y1);
-  }.property('x0', 'y0', 'x1', 'y1'),
+  }),
 
   /**
     Click event handler. Toggles selected if selectable.

--- a/app/components/nf-vertical-line.js
+++ b/app/components/nf-vertical-line.js
@@ -50,9 +50,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  lineX: function(){
+  lineX: Ember.computed('xScale', 'x', function(){
     var xScale = this.get('xScale');
     var x = this.get('x');
     return xScale ? xScale(x) : -1;
-  }.property('xScale', 'x'),
+  }),
 });

--- a/app/components/nf-y-axis.js
+++ b/app/components/nf-y-axis.js
@@ -103,12 +103,12 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
   
     The above example will filter down the set of ticks to only those that are less than 1000.
   */
-  tickFilter: function(name, value) {
+  tickFilter: Ember.computed(function(name, value) {
     if(arguments.length > 1) {
       this._tickFilter = value;
     }
     return this._tickFilter;
-  }.property(),
+  }),
 
   /**
     computed property. returns true if `orient` is equal to `'right'`.
@@ -125,11 +125,11 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type String
     @readonly
   */
-  transform: function(){
+  transform: Ember.computed('x', 'y', function(){
     var x = this.get('x');
     var y = this.get('y');
     return 'translate(%@ %@)'.fmt(x, y);
-  }.property('x', 'y'),
+  }),
 
   /**
     The x position of the component
@@ -137,13 +137,20 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  x: function(){
-    var orient = this.get('orient');
-    if(orient !== 'left') {
-      return this.get('graph.width') - this.get('width') - this.get('graph.paddingRight');
+  x: Ember.computed(
+    'orient',
+    'graph.width',
+    'width',
+    'graph.paddingLeft',
+    'graph.paddingRight',
+    function(){
+      var orient = this.get('orient');
+      if(orient !== 'left') {
+        return this.get('graph.width') - this.get('width') - this.get('graph.paddingRight');
+      }
+      return this.get('graph.paddingLeft');
     }
-    return this.get('graph.paddingLeft');
-  }.property('orient', 'graph.width', 'width', 'graph.paddingLeft', 'graph.paddingRight'),
+  ),
 
   /**
     The y position of the component
@@ -195,38 +202,48 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Array
     @readonly
   */
-  ticks: function(){
-    var yScale = this.get('yScale');
-    var tickCount = this.get('tickCount');
-    var yScaleType = this.get('graph.yScaleType');
-    var tickPadding = this.get('tickPadding');
-    var axisLineX = this.get('axisLineX');
-    var tickLength = this.get('tickLength');
-    var isOrientRight = this.get('isOrientRight');
-    var tickFilter = this.get('tickFilter');
-    var uniqueYData = this.get('uniqueYData');
-    var ticks = this.tickFactory(yScale, tickCount, uniqueYData, yScaleType);
-    var x1 = isOrientRight ? axisLineX + tickLength : axisLineX - tickLength;
-    var x2 = axisLineX;
-    var labelx = isOrientRight ? (tickLength + tickPadding) : (axisLineX - tickLength - tickPadding);
+  ticks: Ember.computed(
+    'yScale',
+    'tickCount',
+    'graph.yScaleType',
+    'tickPadding',
+    'axisLineX',
+    'tickLength',
+    'isOrientRight',
+    'tickFilter',
+    'uniqueYData',
+    function(){
+      var yScale = this.get('yScale');
+      var tickCount = this.get('tickCount');
+      var yScaleType = this.get('graph.yScaleType');
+      var tickPadding = this.get('tickPadding');
+      var axisLineX = this.get('axisLineX');
+      var tickLength = this.get('tickLength');
+      var isOrientRight = this.get('isOrientRight');
+      var tickFilter = this.get('tickFilter');
+      var uniqueYData = this.get('uniqueYData');
+      var ticks = this.tickFactory(yScale, tickCount, uniqueYData, yScaleType);
+      var x1 = isOrientRight ? axisLineX + tickLength : axisLineX - tickLength;
+      var x2 = axisLineX;
+      var labelx = isOrientRight ? (tickLength + tickPadding) : (axisLineX - tickLength - tickPadding);
 
-    var result = ticks.map(function (tick) {
-      return {
-        value: tick,
-        y: yScale(tick),
-        x1: x1,
-        x2: x2,
-        labelx: labelx,
-      };
-    });
+      var result = ticks.map(function (tick) {
+        return {
+          value: tick,
+          y: yScale(tick),
+          x1: x1,
+          x2: x2,
+          labelx: labelx,
+        };
+      });
 
-    if(tickFilter) {
-      result = result.filter(tickFilter);
+      if(tickFilter) {
+        result = result.filter(tickFilter);
+      }
+
+      return result;
     }
-
-    return result;
-  }.property('yScale', 'tickCount', 'graph.yScaleType', 'tickPadding', 'axisLineX', 
-    'tickLength', 'isOrientRight', 'tickFilter', 'uniqueYData'),
+  ),
 
 
   /**
@@ -235,16 +252,16 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  axisLineX: function(){
+  axisLineX: Ember.computed('isOrientRight', 'width', function(){
     return this.get('isOrientRight') ? 0 : this.get('width');
-  }.property('isOrientRight', 'width'),
+  }),
 
   /**
     sets graph's yAxis property on willInsertElement
     @method _updateGraphYAxis
     @private
   */
-  _updateGraphYAxis: function(){
+  _updateGraphYAxis: Ember.on('willInsertElement', function(){
     this.set('graph.yAxis', this);
-  }.on('willInsertElement')
+  })
 });

--- a/app/components/nf-y-diff.js
+++ b/app/components/nf-y-diff.js
@@ -65,29 +65,29 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  yCenter: function(){
+  yCenter: Ember.computed('yA', 'yB', function(){
     var yA = +this.get('yA') || 0;
     var yB = +this.get('yB') || 0;
     return (yA + yB) / 2;
-  }.property('yA', 'yB'),
+  }),
 
   /**
     The y pixel value of b.
     @property yB
     @type Number
   */
-  yB: function(){
+  yB: Ember.computed('yScale', 'b', function(){
     return normalizeScale(this.get('yScale'), this.get('b'));
-  }.property('yScale', 'b'),
+  }),
 
   /**
     The y pixel value of a.
     @property yA
     @type Number
   */
-  yA: function() {
+  yA: Ember.computed('yScale', 'a', function() {
     return normalizeScale(this.get('yScale'), this.get('a'));
-  }.property('yScale', 'a'),
+  }),
 
   /**
     The SVG transformation of the component.
@@ -104,9 +104,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  diff: function(){
+  diff: Ember.computed('a', 'b', function(){
     return +this.get('b') - this.get('a');
-  }.property('a', 'b'),
+  }),
 
   /**
     Returns `true` if `diff` is a positive number
@@ -147,20 +147,20 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @type Number
     @readonly
   */
-  contentX: function(){
+  contentX: Ember.computed('isOrientRight', 'width', 'contentPadding', function(){
     var contentPadding = this.get('contentPadding');
     var width = this.get('width');
     return this.get('isOrientRight') ? width - contentPadding : contentPadding;
-  }.property('isOrientRight', 'width', 'contentPadding'),
+  }),
 
-  rectPath: function(){
+  rectPath: Ember.computed('yA', 'yB', 'width', function(){
     var x = 0;
     var w = +this.get('width') || 0;
     var x2 = x + w;
     var yA = +this.get('yA') || 0;
     var yB = +this.get('yB') || 0;
     return 'M%@1,%@2 L%@1,%@4 L%@3,%@4 L%@3,%@2 L%@1,%@2'.fmt(x, yA, x2, yB);
-  }.property('yA', 'yB', 'width'),
+  }),
 
   /**
     The SVG transformation used to position the content container.
@@ -169,9 +169,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     @private
     @readonly
   */
-  contentTransform: function(){
+  contentTransform: Ember.computed('contentX', 'yCenter', function(){
     return 'translate(%@ %@)'.fmt(this.get('contentX'), this.get('yCenter'));
-  }.property('contentX', 'yCenter'),
+  }),
 
   /**
     Sets up the d3 related elements when component is inserted 
@@ -219,9 +219,9 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     Schedules a transition once at afterRender.
     @method transition
   */
-  transition: function(){
+  transition: Ember.observer('a', 'b', function(){
     Ember.run.once(this, this.doTransition);
-  }.observes('a', 'b'),
+  }),
 
   /**
     Updates to d3 managed DOM elments that do
@@ -236,7 +236,7 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     }
   },
 
-  adjustGraphHeight: function(){
+  adjustGraphHeight: Ember.on('didInsertElement', Ember.observer('graph.graphHeight', function(){
     var rectElement = this.get('rectElement');
     var contentElement = this.get('contentElement');
 
@@ -247,15 +247,18 @@ export default Ember.Component.extend(HasGraphParent, RequireScaleSource, {
     if(contentElement) {
       contentElement.attr('transform', this.get('contentTransform'));
     }
-  }.observes('graph.graphHeight').on('didInsertElement'),
+  })),
 
   /**
     Schedules a call to `doAdjustWidth` on afterRender
     @method adjustWidth
   */
-  adjustWidth: function(){
-    Ember.run.once(this, this.doAdjustWidth);
-  }.observes('isOrientRight', 'width', 'contentPadding').on('didInsertElement'),
+  adjustWidth: Ember.on(
+    'didInsertElement',
+    Ember.observer('isOrientRight', 'width', 'contentPadding', function(){
+      Ember.run.once(this, this.doAdjustWidth);
+    })
+  ),
 });
 
 

--- a/app/views/nf-tick-label.js
+++ b/app/views/nf-tick-label.js
@@ -5,9 +5,9 @@ export default Ember.View.extend({
 
   attributeBindings: ['transform'],
 
-  transform: function(){
+  transform: Ember.computed('x', 'y', function(){
     return 'translate(%@ %@)'.fmt(this.get('x'), this.get('y'));
-  }.property('x', 'y'),
+  }),
 
   className: 'nf-tick-label'
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
+    "ember-disable-prototype-extensions": "^1.0.1",
     "ember-export-application-global": "^1.0.2"
   },
   "keywords": [

--- a/tests/dummy/app/controllers/nf-graph/nf-bars.js
+++ b/tests/dummy/app/controllers/nf-graph/nf-bars.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.ObjectController.extend({
   poop: null,
   
-  data: function() {
+  data: Ember.computed(function() {
     var arr = [];
     var str = 'abcdefg';
     
@@ -18,7 +18,7 @@ export default Ember.ObjectController.extend({
     }
     
     return arr;
-  }.property(),
+  }),
 
   actions: {
     barClicked: function(barData) {


### PR DESCRIPTION
Fixes #8.

**Work in progress** as ember-watson was awesome, but this project (ember-cli-nf-graph) has a mix of spaces/tabs (even within the same file) and so the output formatting got wonky in certain parts, though it doesn't impact how it functions. I've already started fixing them, should be done soon.

From the looks of things, I think it's safe to assume this project prefers 2 space instead of tabs (likely older code was in tabs) and regardless, [ember-watson assumes spaces anyway right now](https://github.com/abuiles/ember-watson/issues/12).